### PR TITLE
Feature/autocomplete staff list no autocomplete

### DIFF
--- a/src/actions/course.js
+++ b/src/actions/course.js
@@ -142,7 +142,6 @@ const addCourseStaffFailure = makeActionCreator(
 export function addCourseStaff(courseId, userId, uid) {
   return dispatch => {
     dispatch(addCourseStaffRequest(courseId, userId, uid))
-    console.log('DISPATCHED: ' + JSON.stringify({ courseId, userId, uid }))
     return axios
       .put(`/api/courses/${courseId}/staff`, { id: userId, uid })
       .then(

--- a/src/actions/course.js
+++ b/src/actions/course.js
@@ -139,17 +139,19 @@ const addCourseStaffFailure = makeActionCreator(
   'data'
 )
 
-export function addCourseStaff(courseId, userId) {
+export function addCourseStaff(courseId, userId, uid) {
   return dispatch => {
-    dispatch(addCourseStaffRequest(courseId, userId))
-
-    return axios.put(`/api/courses/${courseId}/staff/${userId}`).then(
-      res => dispatch(addCourseStaffSuccess(courseId, res.data)),
-      err => {
-        console.error(err)
-        dispatch(addCourseStaffFailure(err))
-      }
-    )
+    dispatch(addCourseStaffRequest(courseId, userId, uid))
+    console.log('DISPATCHED: ' + JSON.stringify({ courseId, userId, uid }))
+    return axios
+      .put(`/api/courses/${courseId}/staff`, { id: userId, uid })
+      .then(
+        res => dispatch(addCourseStaffSuccess(courseId, res.data)),
+        err => {
+          console.error(err)
+          dispatch(addCourseStaffFailure(err))
+        }
+      )
   }
 }
 

--- a/src/api/courses.js
+++ b/src/api/courses.js
@@ -316,6 +316,11 @@ router.put(
     }
 
     const user = await User.findOne(query)
+
+    if (!user) {
+      return _next(new ApiError(404, 'User does not exist'))
+    }
+
     await user.addStaffAssignment(res.locals.course.id)
     return res.status(201).send(user)
   })

--- a/src/api/courses.js
+++ b/src/api/courses.js
@@ -307,24 +307,15 @@ router.put(
   '/:courseId/staff',
   [requireCourseStaff, requireCourse, failIfErrors],
   safeAsync(async (req, res, _next) => {
-    console.log(req.params)
     const id = req.body.id ? req.body.id : null
     const uid = req.body.uid ? req.body.uid : null
-
-    let query = null
+    const query = id ? { where: { id } } : { where: { uid } }
 
     if (!id && !uid) {
       return _next(new ApiError(400, 'User id or uid expected'))
     }
 
-    if (!id) {
-      query = { where: { uid } }
-    } else {
-      query = { where: { id } }
-    }
-
     const user = await User.findOne(query)
-    // const { user } = res.locals
     await user.addStaffAssignment(res.locals.course.id)
     return res.status(201).send(user)
   })

--- a/src/api/courses.js
+++ b/src/api/courses.js
@@ -318,7 +318,9 @@ router.put(
     const user = await User.findOne(query)
 
     if (!user) {
-      return _next(new ApiError(404, 'User does not exist'))
+      return _next(
+        new ApiError(404, 'User does not exist. Has user logged in?')
+      )
     }
 
     await user.addStaffAssignment(res.locals.course.id)

--- a/src/api/courses.test.js
+++ b/src/api/courses.test.js
@@ -316,6 +316,22 @@ describe('Courses API', () => {
       expect(res1.statusCode).toBe(403)
       expect(res2.statusCode).toBe(403)
     })
+
+    test('fails when adding non-existent user', async () => {
+      const request = await requestAsUser(app, 'admin@illinois.edu')
+      const res1 = await request.put('/api/courses/1/staff').send({ id: 99999 })
+      const res2 = await request
+        .put('/api/courses/1/staff')
+        .send({ uid: 'fakeuser@fake.com' })
+      expect(res1.statusCode).toBe(404)
+      expect(res2.statusCode).toBe(404)
+      expect(JSON.parse(res1.error.text).message).toBe(
+        'User does not exist. Has user logged in?'
+      )
+      expect(JSON.parse(res2.error.text).message).toBe(
+        'User does not exist. Has user logged in?'
+      )
+    })
   })
 
   describe('DELETE /api/courses/:courseId/staff/:userId', () => {

--- a/src/api/courses.test.js
+++ b/src/api/courses.test.js
@@ -272,31 +272,49 @@ describe('Courses API', () => {
     test('succeeds for admin', async () => {
       const request = await requestAsUser(app, 'admin@illinois.edu')
       // This is the "241staff" user
-      const res = await request.put('/api/courses/1/staff/4').send()
-      expect(res.statusCode).toBe(201)
-      expect(res.body.uid).toBe('241staff@illinois.edu')
+      const res1 = await request.put('/api/courses/1/staff').send({ id: 4 })
+      const res2 = await request
+        .put('/api/courses/1/staff')
+        .send({ uid: '241staff@illinois.edu' })
+      expect(res1.statusCode).toBe(201)
+      expect(res1.body.uid).toBe('241staff@illinois.edu')
+      expect(res2.statusCode).toBe(201)
+      expect(res2.body.uid).toBe('241staff@illinois.edu')
     })
 
     test('succeeds for course staff', async () => {
       const request = await requestAsUser(app, '225staff@illinois.edu')
       // This is the "241staff" user
-      const res = await request.put('/api/courses/1/staff/4').send()
-      expect(res.statusCode).toBe(201)
-      expect(res.body.uid).toBe('241staff@illinois.edu')
+      const res1 = await request.put('/api/courses/1/staff').send({ id: 4 })
+      const res2 = await request
+        .put('/api/courses/1/staff')
+        .send({ uid: '241staff@illinois.edu' })
+      expect(res1.statusCode).toBe(201)
+      expect(res2.statusCode).toBe(201)
+      expect(res1.body.uid).toBe('241staff@illinois.edu')
+      expect(res2.body.uid).toBe('241staff@illinois.edu')
     })
 
     test('fails for course staff of different course', async () => {
       const request = await requestAsUser(app, '241staff@illinois.edu')
       // This is the "241staff" user
-      const res = await request.put('/api/courses/1/staff/4').send()
-      expect(res.statusCode).toBe(403)
+      const res1 = await request.put('/api/courses/1/staff').send({ id: 4 })
+      const res2 = await request
+        .put('/api/courses/1/staff')
+        .send({ uid: '241staff@illinois.edu' })
+      expect(res1.statusCode).toBe(403)
+      expect(res2.statusCode).toBe(403)
     })
 
     test('fails for student', async () => {
       const request = await requestAsUser(app, '241staff@illinois.edu')
       // This is the "241staff" user
-      const res = await request.put('/api/courses/1/staff/4').send()
-      expect(res.statusCode).toBe(403)
+      const res1 = await request.put('/api/courses/1/staff').send({ id: 4 })
+      const res2 = await request
+        .put('/api/courses/1/staff')
+        .send({ uid: '241staff@illinois.edu' })
+      expect(res1.statusCode).toBe(403)
+      expect(res2.statusCode).toBe(403)
     })
   })
 

--- a/src/components/AddStaff.js
+++ b/src/components/AddStaff.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import {
   Form,
@@ -13,16 +14,32 @@ import UserAutocomplete from './UserAutocomplete'
 const { uidName, uidArticle } = getConfig().publicRuntimeConfig
 
 const AddStaff = props => {
+  const { user } = props
   const [pendingUser, setPendingUser] = useState([])
+  const [uidInput, setUidInput] = useState()
 
   const handleAddStaff = e => {
     if (e) e.preventDefault()
-    props.onAddStaff(pendingUser[0])
+    console.log(
+      'AddStaff:: handleAddStaff - pendingUser[0] ' +
+        JSON.stringify(pendingUser[0])
+    )
+    console.log(
+      'AddStaff:: handleAddStaff - uidInput ' + JSON.stringify(uidInput)
+    )
+    if (pendingUser[0]) {
+      props.onAddStaff(pendingUser[0].id, null)
+    }
+    console.log(
+      'pending user, which leads to onAddStaff attribute on AddStaff/ element',
+      pendingUser[0]
+    )
+    props.onAddStaff(null, uidInput)
   }
 
   // We want to exclude existing staff from the autocompletion list
   const filterBy = option => {
-    return props.existingStaff.findIndex(user => user === option.id) === -1
+    return props.existingStaff.findIndex(u => u === option.id) === -1
   }
   return (
     <FormGroup>
@@ -35,6 +52,7 @@ const AddStaff = props => {
         <InputGroup>
           <UserAutocomplete
             id="user-input"
+            setUidInput={setUidInput}
             selected={pendingUser}
             onChange={setPendingUser}
             placeholder={`Enter ${uidArticle} ${uidName}`}
@@ -45,7 +63,7 @@ const AddStaff = props => {
               color="primary"
               type="button"
               onClick={handleAddStaff}
-              disabled={pendingUser.length === 0}
+              disabled={user.isAdmin && pendingUser.length === 0}
             >
               Add staff
             </Button>
@@ -57,6 +75,9 @@ const AddStaff = props => {
 }
 
 AddStaff.propTypes = {
+  user: PropTypes.shape({
+    isAdmin: PropTypes.bool,
+  }).isRequired,
   // This is just an array of user IDs (not UIDs)
   existingStaff: PropTypes.arrayOf(PropTypes.number),
   onAddStaff: PropTypes.func.isRequired,
@@ -66,4 +87,8 @@ AddStaff.defaultProps = {
   existingStaff: [],
 }
 
-export default AddStaff
+const mapStateToProps = state => ({
+  user: state.user.user,
+})
+
+export default connect(mapStateToProps)(AddStaff)

--- a/src/components/AddStaff.js
+++ b/src/components/AddStaff.js
@@ -28,13 +28,13 @@ const AddStaff = props => {
       'AddStaff:: handleAddStaff - uidInput ' + JSON.stringify(uidInput)
     )
     if (pendingUser[0]) {
-      props.onAddStaff(pendingUser[0].id, null)
+      return props.onAddStaff(pendingUser[0].id, null)
     }
     console.log(
       'pending user, which leads to onAddStaff attribute on AddStaff/ element',
       pendingUser[0]
     )
-    props.onAddStaff(null, uidInput)
+    return props.onAddStaff(null, uidInput)
   }
 
   // We want to exclude existing staff from the autocompletion list

--- a/src/components/AddStaff.js
+++ b/src/components/AddStaff.js
@@ -20,20 +20,9 @@ const AddStaff = props => {
 
   const handleAddStaff = e => {
     if (e) e.preventDefault()
-    console.log(
-      'AddStaff:: handleAddStaff - pendingUser[0] ' +
-        JSON.stringify(pendingUser[0])
-    )
-    console.log(
-      'AddStaff:: handleAddStaff - uidInput ' + JSON.stringify(uidInput)
-    )
     if (pendingUser[0]) {
       return props.onAddStaff(pendingUser[0].id, null)
     }
-    console.log(
-      'pending user, which leads to onAddStaff attribute on AddStaff/ element',
-      pendingUser[0]
-    )
     return props.onAddStaff(null, uidInput)
   }
 

--- a/src/components/UserAutocomplete.jsx
+++ b/src/components/UserAutocomplete.jsx
@@ -7,9 +7,9 @@ import { useDebounce } from 'use-debounce'
 import { CancelToken } from 'axios'
 import {
   AsyncTypeahead,
+  Highlighter,
   Menu,
   MenuItem,
-  Highlighter,
 } from 'react-bootstrap-typeahead'
 
 import 'react-bootstrap-typeahead/css/Typeahead.css'
@@ -18,8 +18,7 @@ import 'react-bootstrap-typeahead/css/Typeahead-bs4.css'
 import axios from '../actions/axios'
 
 const UserAutocomplete = props => {
-  const { user } = props
-  const { setUidInput } = props
+  const { user, setUidInput } = props
   const uidInput = useInput('')
   const [uidQuery] = useDebounce(uidInput.value, 300)
   const [userSuggestions, setUserSuggestions] = useState([])
@@ -30,12 +29,7 @@ const UserAutocomplete = props => {
       return <></>
     }
     const items = results.map((result, idx) => (
-      <MenuItem
-        key={result.id}
-        option={result}
-        position={idx}
-        className="GlobalSearchTypeahead__option"
-      >
+      <MenuItem key={result.id} option={result} position={idx}>
         <Highlighter search={menuProps.text}>{result.uid}</Highlighter>
         {result.name && (
           <span className="text-muted ml-2">({result.name})</span>
@@ -96,7 +90,6 @@ const UserAutocomplete = props => {
         autoComplete: 'new-user-uid',
         ...inputProps,
       }}
-      // renderMenu={renderMenu}
       renderMenu={renderMenu}
       {...restProps}
     />
@@ -107,6 +100,7 @@ UserAutocomplete.propTypes = {
   user: PropTypes.shape({
     uid: PropTypes.string,
     userId: PropTypes.string,
+    isAdmin: PropTypes.bool,
   }).isRequired,
   selected: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/components/UserAutocomplete.jsx
+++ b/src/components/UserAutocomplete.jsx
@@ -1,10 +1,16 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
+import { connect } from 'react-redux'
 import { useInput } from 'react-hanger'
 import { useDebounce } from 'use-debounce'
 import { CancelToken } from 'axios'
-import { AsyncTypeahead, Highlighter } from 'react-bootstrap-typeahead'
+import {
+  AsyncTypeahead,
+  Menu,
+  MenuItem,
+  Highlighter,
+} from 'react-bootstrap-typeahead'
 
 import 'react-bootstrap-typeahead/css/Typeahead.css'
 import 'react-bootstrap-typeahead/css/Typeahead-bs4.css'
@@ -12,6 +18,8 @@ import 'react-bootstrap-typeahead/css/Typeahead-bs4.css'
 import axios from '../actions/axios'
 
 const UserAutocomplete = props => {
+  const { user } = props
+  const { setUidInput } = props
   const uidInput = useInput('')
   const [uidQuery] = useDebounce(uidInput.value, 300)
   const [userSuggestions, setUserSuggestions] = useState([])
@@ -22,24 +30,27 @@ const UserAutocomplete = props => {
       return () => {}
     }
     const source = CancelToken.source()
-    setUserSuggestionsLoading(true)
-    axios
-      .get('/api/autocomplete/users', {
-        params: {
-          q: uidQuery,
-        },
-        cancelToken: source.token,
-      })
-      .then(res => {
-        ReactDOM.unstable_batchedUpdates(() => {
-          // The typeahead component will filter out existing admins
-          setUserSuggestions(res.data)
-          setUserSuggestionsLoading(false)
+    console.log('user', user)
+    if (user.isAdmin) {
+      setUserSuggestionsLoading(true)
+      axios
+        .get('/api/autocomplete/users', {
+          params: {
+            q: uidQuery,
+          },
+          cancelToken: source.token,
         })
-      })
-      .catch(err => {
-        console.error(err)
-      })
+        .then(res => {
+          ReactDOM.unstable_batchedUpdates(() => {
+            // The typeahead component will filter out existing admins
+            setUserSuggestions(res.data)
+            setUserSuggestionsLoading(false)
+          })
+        })
+        .catch(err => {
+          console.error(err)
+        })
+    }
     return () => {
       source.cancel()
     }
@@ -55,7 +66,12 @@ const UserAutocomplete = props => {
         /* This is handled by hooks, but prop must be specified */
       }}
       labelKey="uid"
-      onInputChange={value => uidInput.setValue(value)}
+      onInputChange={value => {
+        uidInput.setValue(value)
+        // setPendingUser([{ uid: value }])
+        setUidInput(value)
+        console.log('uidInput and setPendingUser u.uid', uidInput)
+      }}
       minLength={1}
       useCache={false}
       // Attempt to force Chrome to hide the native email autocomplete
@@ -63,6 +79,15 @@ const UserAutocomplete = props => {
         autoComplete: 'new-user-uid',
         ...inputProps,
       }}
+      // renderMenu={(results, menuProps) => {
+      //   // Hide the menu when there are no results.
+      //   if (!results.length) {
+      //     return null
+      //   }
+      //   return (    <Menu {...menuProps}>
+
+      //   </Menu>)
+      // }}
       renderMenuItemChildren={(option, typeaheadProps) => {
         return (
           <>
@@ -79,11 +104,16 @@ const UserAutocomplete = props => {
 }
 
 UserAutocomplete.propTypes = {
+  user: PropTypes.shape({
+    universityName: PropTypes.string,
+    preferredName: PropTypes.string,
+  }).isRequired,
   selected: PropTypes.arrayOf(
     PropTypes.shape({
       uid: PropTypes.string,
     })
   ),
+  setUidInput: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
   // We don't know exactly what these props will be
   // eslint-disable-next-line react/forbid-prop-types
@@ -95,4 +125,8 @@ UserAutocomplete.defaultProps = {
   inputProps: {},
 }
 
-export default UserAutocomplete
+const mapStateToProps = state => ({
+  user: state.user.user,
+})
+
+export default connect(mapStateToProps)(UserAutocomplete)

--- a/src/components/UserAutocomplete.jsx
+++ b/src/components/UserAutocomplete.jsx
@@ -24,16 +24,25 @@ const UserAutocomplete = props => {
   const [uidQuery] = useDebounce(uidInput.value, 300)
   const [userSuggestions, setUserSuggestions] = useState([])
   const [userSuggestionsLoading, setUserSuggestionsLoading] = useState(false)
-  const renderMenu = (results, menuProps, _props) => {
-    console.log('results', results)
-    console.log('menuProps', menuProps)
-    console.log('props', _props)
-    const menuItems = results.map((result, idx) => {
-      console.log('result', result)
-      console.log('idx', idx)
-      return null
-    })
-    return null
+  const renderMenu = (results, menuProps) => {
+    // Hide the autocomplete when user is staff
+    if (!user.isAdmin) {
+      return <></>
+    }
+    const items = results.map((result, idx) => (
+      <MenuItem
+        key={result.id}
+        option={result}
+        position={idx}
+        className="GlobalSearchTypeahead__option"
+      >
+        <Highlighter search={menuProps.text}>{result.uid}</Highlighter>
+        {result.name && (
+          <span className="text-muted ml-2">({result.name})</span>
+        )}
+      </MenuItem>
+    ))
+    return <Menu {...menuProps}>{items}</Menu>
   }
 
   useEffect(() => {
@@ -41,7 +50,6 @@ const UserAutocomplete = props => {
       return () => {}
     }
     const source = CancelToken.source()
-    console.log('user', user)
     if (user.isAdmin) {
       setUserSuggestionsLoading(true)
       axios
@@ -79,9 +87,7 @@ const UserAutocomplete = props => {
       labelKey="uid"
       onInputChange={value => {
         uidInput.setValue(value)
-        // setPendingUser([{ uid: value }])
         setUidInput(value)
-        console.log('uidInput and setPendingUser u.uid', uidInput)
       }}
       minLength={1}
       useCache={false}
@@ -91,26 +97,7 @@ const UserAutocomplete = props => {
         ...inputProps,
       }}
       // renderMenu={renderMenu}
-      renderMenu={(results, menuProps, props) => {
-        // Hide the autocomplete when user is not admin
-        if (!user.isAdmin) {
-          return <></>
-        }
-        const items = results.map((result, idx) => (
-          <MenuItem
-            key={result.id}
-            option={result}
-            position={idx}
-            className="GlobalSearchTypeahead__option"
-          >
-            <Highlighter search={menuProps.text}>{result.uid}</Highlighter>
-            {result.name && (
-              <span className="text-muted ml-2">({result.name})</span>
-            )}
-          </MenuItem>
-        ))
-        return <Menu {...menuProps}>{items}</Menu>
-      }}
+      renderMenu={renderMenu}
       {...restProps}
     />
   )
@@ -118,8 +105,8 @@ const UserAutocomplete = props => {
 
 UserAutocomplete.propTypes = {
   user: PropTypes.shape({
-    universityName: PropTypes.string,
-    preferredName: PropTypes.string,
+    uid: PropTypes.string,
+    userId: PropTypes.string,
   }).isRequired,
   selected: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/components/UserAutocomplete.jsx
+++ b/src/components/UserAutocomplete.jsx
@@ -24,6 +24,17 @@ const UserAutocomplete = props => {
   const [uidQuery] = useDebounce(uidInput.value, 300)
   const [userSuggestions, setUserSuggestions] = useState([])
   const [userSuggestionsLoading, setUserSuggestionsLoading] = useState(false)
+  const renderMenu = (results, menuProps, _props) => {
+    console.log('results', results)
+    console.log('menuProps', menuProps)
+    console.log('props', _props)
+    const menuItems = results.map((result, idx) => {
+      console.log('result', result)
+      console.log('idx', idx)
+      return null
+    })
+    return null
+  }
 
   useEffect(() => {
     if (!uidQuery) {
@@ -79,24 +90,26 @@ const UserAutocomplete = props => {
         autoComplete: 'new-user-uid',
         ...inputProps,
       }}
-      // renderMenu={(results, menuProps) => {
-      //   // Hide the menu when there are no results.
-      //   if (!results.length) {
-      //     return null
-      //   }
-      //   return (    <Menu {...menuProps}>
-
-      //   </Menu>)
-      // }}
-      renderMenuItemChildren={(option, typeaheadProps) => {
-        return (
-          <>
-            <Highlighter search={typeaheadProps.text}>{option.uid}</Highlighter>
-            {option.name && (
-              <span className="text-muted ml-2">({option.name})</span>
+      // renderMenu={renderMenu}
+      renderMenu={(results, menuProps, props) => {
+        // Hide the autocomplete when user is not admin
+        if (!user.isAdmin) {
+          return <></>
+        }
+        const items = results.map((result, idx) => (
+          <MenuItem
+            key={result.id}
+            option={result}
+            position={idx}
+            className="GlobalSearchTypeahead__option"
+          >
+            <Highlighter search={menuProps.text}>{result.uid}</Highlighter>
+            {result.name && (
+              <span className="text-muted ml-2">({result.name})</span>
             )}
-          </>
-        )
+          </MenuItem>
+        ))
+        return <Menu {...menuProps}>{items}</Menu>
       }}
       {...restProps}
     />

--- a/src/components/courseSettings/ManageStaffPanel.tsx
+++ b/src/components/courseSettings/ManageStaffPanel.tsx
@@ -27,7 +27,7 @@ interface ManageStaffPanelProps {
     name: string
   }[]
   removeCourseStaff: (courseId: number, userId: number) => void
-  addCourseStaff: (courseId: number, uid: string, name: string) => void
+  addCourseStaff: (courseId: number, userId: string, uid: string) => void
 }
 
 const ManageStaffPanel = ({
@@ -67,9 +67,10 @@ const ManageStaffPanel = ({
       </CardHeader>
       <CardBody>
         <AddStaff
-          onAddStaff={(staff: Record<string, string>) => {
-            const { id, name } = staff
-            addCourseStaff(course.id, id, name)
+          onAddStaff={(userId: string, uid: string) => {
+            console.log('ManageStaffPanel:: onAddStaff userId: ' + userId)
+            console.log('ManageStaffPanel:: onAddStaff uid: ' + uid)
+            addCourseStaff(course.id, userId, uid)
           }}
         />
         <ListGroup flush className="position-relative">

--- a/src/components/courseSettings/ManageStaffPanel.tsx
+++ b/src/components/courseSettings/ManageStaffPanel.tsx
@@ -68,8 +68,6 @@ const ManageStaffPanel = ({
       <CardBody>
         <AddStaff
           onAddStaff={(userId: string, uid: string) => {
-            console.log('ManageStaffPanel:: onAddStaff userId: ' + userId)
-            console.log('ManageStaffPanel:: onAddStaff uid: ' + uid)
             addCourseStaff(course.id, userId, uid)
           }}
         />

--- a/src/pages/courseSettings.js
+++ b/src/pages/courseSettings.js
@@ -111,8 +111,8 @@ const mapStateToProps = (state, ownProps) => ({
 
 const mapDispatchToProps = dispatch => ({
   fetchCourse: courseId => dispatch(fetchCourse(courseId)),
-  addCourseStaff: (courseId, uid, name) =>
-    dispatch(addCourseStaff(courseId, uid, name)),
+  addCourseStaff: (courseId, userId, uid) =>
+    dispatch(addCourseStaff(courseId, userId, uid)),
   removeCourseStaff: (courseId, userId) =>
     dispatch(removeCourseStaff(courseId, userId)),
   updateCourse: (courseId, attributes) =>


### PR DESCRIPTION
Description: A staff user would attempt to add another staff user and experience a permissions error where  an `Autocomplete` component would attempt to fetch user information that the staff role should not have access to.

Fix: Enable autocorrect for the admin user role, but only allow manual entries for the staff user role.

Some questions that I had in the PR draft (answered in comment below):
- Is the filter working (and was it ever working) to filter out pre-existing users / admins
- Where else is Userautocomplete used and did my changes break anything? (cannot tell by tests at the moment)
- Do I need to connect and map the state to props in both components?
- Are the prop shapes necessary, or even the best prop option?
- Have the number of passing tests / failing tests changed?
- Write unit tests.